### PR TITLE
Markdown chunkers

### DIFF
--- a/src/Microsoft.Extensions.DataIngestion.Abstractions/Chunk.cs
+++ b/src/Microsoft.Extensions.DataIngestion.Abstractions/Chunk.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Extensions.DataIngestion
     public sealed class Chunk
     {
         public string Content { get; }
-        public int TokenCount { get; }
+        public int? TokenCount { get; }
 
         public string? Context { get; }
 
-        public Chunk(string content, int tokenCount, string? context = null)
+        public Chunk(string content, int? tokenCount = null, string? context = null)
         {
             if (string.IsNullOrWhiteSpace(content))
                 throw new ArgumentException("Content cannot be null or whitespace.", nameof(content));

--- a/test/Microsoft.Extensions.DataIngestion.Tests/DocumentChunkerTests.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/DocumentChunkerTests.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Extensions.DataIngestion.Tests
+{
+    public abstract class DocumentChunkerTests
+    {
+        protected abstract DocumentChunker CreateDocumentChunker();
+
+        [Fact]
+        public async Task ProcessAsync_ThrowsArgumentNullException_WhenDocumentIsNull()
+        {
+            var chunker = CreateDocumentChunker();
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await chunker.ProcessAsync(null));
+        }
+
+        [Fact]
+        public async Task EmptyDocument()
+        {
+            Document emptyDoc = new("emptyDoc");
+            DocumentChunker chunker = CreateDocumentChunker();
+
+            List<Chunk> chunks = await chunker.ProcessAsync(emptyDoc);
+            Assert.Empty(chunks);
+        }
+    }
+}

--- a/test/Microsoft.Extensions.DataIngestion.Tests/DocumentTokenChunker/DocumentTokenChunker.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/DocumentTokenChunker/DocumentTokenChunker.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.ML.Tokenizers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.DataIngestion.Tests
+{
+    internal class DocumentTokenChunker : DocumentChunker
+    {
+        private readonly Tokenizer _tokenizer;
+        private readonly int _chunkSize;
+        private readonly int _chunkOverlap;
+        public DocumentTokenChunker(Tokenizer tokenizer, int chunkSize, int chunkOverlap)
+        {
+            if (chunkOverlap >= chunkSize)
+                throw new ArgumentException("Chunk overlap must be less than chunk size.", nameof(chunkOverlap));
+
+            _tokenizer = tokenizer ?? throw new ArgumentNullException(nameof(tokenizer));
+            _chunkSize = chunkSize > 0 ? chunkSize : throw new ArgumentOutOfRangeException(nameof(chunkSize));
+            _chunkOverlap = chunkOverlap >= 0 ? chunkOverlap : throw new ArgumentOutOfRangeException(nameof(chunkOverlap));
+        }
+
+        public override ValueTask<List<Chunk>> ProcessAsync(Document document, CancellationToken cancellationToken = default)
+        {
+            if (document is null) throw new ArgumentNullException(nameof(document));
+
+            var tokens = _tokenizer.EncodeToIds(document.Markdown);
+            var token_groups = CreateGroups(tokens);
+            List<Chunk> text_groups = token_groups.Select(GroupToChunk).ToList();
+
+
+            return new ValueTask<List<Chunk>>(text_groups);
+        }
+        // Additional methods for chunking documents would go here.
+
+        private List<List<int>> CreateGroups(IReadOnlyCollection<int> tokens)
+        {
+            List<List<int>> groups = new List<List<int>>();
+            for (int i = 0; i < tokens.Count; i += (_chunkSize - _chunkOverlap))
+            {
+                var chunk = tokens.Skip(i).Take(_chunkSize).ToList();
+                if (chunk.Any())
+                {
+                    groups.Add(chunk);
+                }
+            }
+            return groups;
+        }
+
+        private Chunk GroupToChunk(List<int> tokenGroup)
+        {
+            string text = _tokenizer.Decode(tokenGroup);
+            return new Chunk(text, tokenGroup.Count);
+        }
+    }
+}

--- a/test/Microsoft.Extensions.DataIngestion.Tests/DocumentTokenChunker/DocumentTokenChunkerTests.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/DocumentTokenChunker/DocumentTokenChunkerTests.cs
@@ -1,0 +1,110 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.ML.Tokenizers;
+using Xunit;
+
+namespace Microsoft.Extensions.DataIngestion.Tests
+{
+    public class DocumentTokenChunkerTests : DocumentChunkerTests
+    {
+        protected override DocumentChunker CreateDocumentChunker()
+        {
+            var tokenizer = TiktokenTokenizer.CreateForModel("gpt-4o");
+            int chunkSize = 512;
+            int chunkOverlap = 128;
+            return new DocumentTokenChunker(tokenizer, chunkSize, chunkOverlap);
+        }
+
+        private DocumentTokenChunker CreateNoOverlapTokenChkunker()
+        {
+            var tokenizer = TiktokenTokenizer.CreateForModel("gpt-4o");
+            int chunkSize = 512;
+            int chunkOverlap = 0;
+            return new DocumentTokenChunker(tokenizer, chunkSize, chunkOverlap);
+        }
+
+        [Fact]
+        public async Task Placeholder()
+        {
+            // Placeholder test to ensure the test class is recognized by the test framework.
+            Assert.True(true);
+        }
+
+        [Fact]
+        public async Task SingleChunkText()
+        {
+            string text = "This is a short document that fits within a single chunk.";
+            Document doc = new Document("singleChunkDoc")
+            {
+                Markdown = text
+            };
+            DocumentChunker chunker = CreateDocumentChunker();
+            List<Chunk> chunks = await chunker.ProcessAsync(doc);
+            Assert.Single(chunks);
+            Chunk chunk = chunks.First();
+            Assert.Equal(text, chunk.Content.Trim());
+        }
+
+        [Fact]
+        public async Task TwoChunks_NoOverlap()
+        {
+            string text = string.Join(" ", Enumerable.Repeat("word", 600)); // 600 words
+            Document doc = new Document("twoChunksNoOverlapDoc")
+            {
+                Markdown = text
+            };
+            DocumentChunker chunker = CreateNoOverlapTokenChkunker();
+            List<Chunk> chunks = await chunker.ProcessAsync(doc);
+            Assert.Equal(2, chunks.Count);
+            Assert.True(chunks[0].Content.Split(' ').Length <= 512);
+            Assert.True(chunks[1].Content.Split(' ').Length <= 512);
+            Assert.Equal(text, string.Join("", chunks.Select(c => c.Content)));
+        }
+
+        [Fact]
+        public async Task TokenChunking_WithOverlap_Example()
+        {
+            // Arrange
+            string text = "The quick brown fox jumps over the lazy dog";
+            var tokenizer = TiktokenTokenizer.CreateForModel("gpt-4o");
+            int chunkSize = 4;  // Small chunk size to demonstrate overlap
+            int chunkOverlap = 1;
+
+            var chunker = new DocumentTokenChunker(tokenizer, chunkSize, chunkOverlap);
+            Document doc = new Document("overlapExample")
+            {
+                Markdown = text
+            };
+
+            List<Chunk> chunks = await chunker.ProcessAsync(doc);
+            Assert.Equal(3, chunks.Count);
+
+            foreach (var chunk in chunks.Take(chunks.Count - 1))
+            {
+                Assert.Equal(chunkSize, chunk.TokenCount);
+            }
+
+            Assert.True(chunks.Last().TokenCount <= chunkSize);
+
+            for (int i = 0; i < chunks.Count - 1; i++)
+            {
+                var currentChunk = chunks[i];
+                var nextChunk = chunks[i + 1];
+
+                var currentWords = currentChunk.Content.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                var nextWords = nextChunk.Content.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+                bool hasOverlap = currentWords.Intersect(nextWords).Any();
+                Assert.True(hasOverlap, $"Chunks {i} and {i + 1} should have overlapping content");
+            }
+            Assert.NotEmpty(string.Concat(chunks.Select(c => c.Content)));
+        }
+    }
+}

--- a/test/Microsoft.Extensions.DataIngestion.Tests/DummyChunker/DummyChunker.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/DummyChunker/DummyChunker.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,6 +14,8 @@ public class DummyChunker : DocumentChunker
 
     public override ValueTask<List<Chunk>> ProcessAsync(Document document, CancellationToken cancellationToken = default)
     {
+        if (document is null) throw new ArgumentNullException(nameof(document));
+
         List<Chunk> chunks = new();
         foreach (DocumentSection section in document.Sections)
         {

--- a/test/Microsoft.Extensions.DataIngestion.Tests/DummyChunker/DummyChunkerTests.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/DummyChunker/DummyChunkerTests.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.DataIngestion.Tests
+{
+    public class DummyChunkerTests : DocumentChunkerTests
+    {
+        protected override DocumentChunker CreateDocumentChunker()
+        {
+            return new DummyChunker();
+        }
+    }
+}

--- a/test/Microsoft.Extensions.DataIngestion.Tests/MakdownChunker/MarkdownChunker.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/MakdownChunker/MarkdownChunker.cs
@@ -107,16 +107,7 @@ namespace Microsoft.Extensions.DataIngestion.Tests
             if (string.IsNullOrEmpty(line))
                 return 0;
 
-            int count = 0;
-            foreach (char c in line)
-            {
-                if (c == '#')
-                    count++;
-                else
-                    break;
-            }
-
-            return count;
+            return line.TakeWhile(c => c == '#').Count();
         }
     }
 

--- a/test/Microsoft.Extensions.DataIngestion.Tests/MakdownChunker/MarkdownChunker.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/MakdownChunker/MarkdownChunker.cs
@@ -1,0 +1,140 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Mime;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.DataIngestion.Tests.MakdownChunker
+{
+    public sealed class MarkdownChunker : DocumentChunker
+    {
+        private readonly int _headerLevelToSplitOn;
+        private readonly bool _stripHeaders;
+
+
+        public MarkdownChunker(MarkdownHeaderLevel HeaderLevelToSplitOn = MarkdownHeaderLevel.Header3, bool StripHeaders = true)
+        {
+            _headerLevelToSplitOn = (int)HeaderLevelToSplitOn;
+            _stripHeaders = StripHeaders;
+        }
+
+        public override ValueTask<List<Chunk>> ProcessAsync(Document document, CancellationToken cancellationToken = default)
+        {
+            string markdown = document.Markdown.ReplaceLineEndings();
+            string[] lines = markdown.Split(Environment.NewLine);
+
+            var lineStack = new Stack<string>(lines.Reverse());
+            return new ValueTask<List<Chunk>>(ParseLevel(lineStack, 1));
+        }
+
+        private List<Chunk> ParseLevel(Stack<string> lines, int markdownHeaderLevel, string context = null, string lastHeader = null)
+        {
+            List<Chunk> chunks = new List<Chunk>();
+
+            StringBuilder sb = new StringBuilder();
+
+            while (lines.Any())
+            {
+                string line = lines.Pop();
+
+                int leadingHashes = CountLeadingHashes(line.Trim());
+                if (leadingHashes == 0 || leadingHashes > _headerLevelToSplitOn)
+                {
+                    sb.AppendLine(line);
+                }
+                else
+                {
+                    Chunk? currentChunk = CreateChunk(sb, context, lastHeader);
+                    if (currentChunk is not null)
+                    {
+                        chunks.Add(currentChunk);
+                    }
+                    sb.Clear();
+
+                    if (leadingHashes == markdownHeaderLevel)
+                    {
+                        lastHeader = line;                        
+                    }
+                    else if (leadingHashes < markdownHeaderLevel)
+                    {
+                        lines.Push(line);
+                        return chunks;
+                    }
+                    else
+                    {
+                        string newContext = StringyfyContext(context, lastHeader);
+                        chunks.AddRange(ParseLevel(lines, markdownHeaderLevel + 1, newContext, line));
+                    }
+
+                }
+            }
+
+            Chunk? chunk = CreateChunk(sb, context, lastHeader);
+            if (chunk is not null)
+            {
+                chunks.Add(chunk);
+            }
+
+            return chunks;
+        }
+
+        private static string StringyfyContext(string? context, string? lastHeader)
+        {
+            return String.Join(';', new[] { context, lastHeader }.Where(x => x is not null));
+        }
+
+        private Chunk? CreateChunk(StringBuilder content, string context, string? header)
+        {
+            context = StringyfyContext(context, header);
+            if (!_stripHeaders)
+            {
+                content.Insert(0, context);
+            }
+            string textContent = content.ToString();
+            if (string.IsNullOrWhiteSpace(textContent))
+                return null;
+            int tokenCount = CountTokens();
+            return new Chunk(textContent, tokenCount, context); 
+        }
+
+        private static int CountTokens()
+        {
+            // This method is a placeholder to match the original code structure.
+            // In a real implementation, it would count tokens in the markdown content.
+            return 1;
+        }
+
+        private static int CountLeadingHashes(string line)
+        {
+            if (string.IsNullOrEmpty(line))
+                return 0;
+
+            int count = 0;
+            foreach (char c in line)
+            {
+                if (c == '#')
+                    count++;
+                else
+                    break;
+            }
+
+            return count;
+        }
+    }
+
+    public enum MarkdownHeaderLevel
+    {
+        Header1 = 1,
+        Header2 = 2,
+        Header3 = 3,
+        Header4 = 4,
+        Header5 = 5,
+        Header6 = 6
+    }
+}

--- a/test/Microsoft.Extensions.DataIngestion.Tests/MakdownChunker/MarkdownChunker.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/MakdownChunker/MarkdownChunker.cs
@@ -99,15 +99,7 @@ namespace Microsoft.Extensions.DataIngestion.Tests.MakdownChunker
             string textContent = content.ToString();
             if (string.IsNullOrWhiteSpace(textContent))
                 return null;
-            int tokenCount = CountTokens();
-            return new Chunk(textContent, tokenCount, context); 
-        }
-
-        private static int CountTokens()
-        {
-            // This method is a placeholder to match the original code structure.
-            // In a real implementation, it would count tokens in the markdown content.
-            return 1;
+            return new Chunk(textContent, context: context); 
         }
 
         private static int CountLeadingHashes(string line)

--- a/test/Microsoft.Extensions.DataIngestion.Tests/MakdownChunker/MarkdownChunker.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/MakdownChunker/MarkdownChunker.cs
@@ -3,14 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Net.Mime;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Extensions.DataIngestion.Tests.MakdownChunker
+namespace Microsoft.Extensions.DataIngestion.Tests
 {
     public sealed class MarkdownChunker : DocumentChunker
     {
@@ -26,6 +24,8 @@ namespace Microsoft.Extensions.DataIngestion.Tests.MakdownChunker
 
         public override ValueTask<List<Chunk>> ProcessAsync(Document document, CancellationToken cancellationToken = default)
         {
+            if (document is null) throw new ArgumentNullException(nameof(document));
+
             string markdown = document.Markdown.ReplaceLineEndings();
             string[] lines = markdown.Split(Environment.NewLine);
 
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.DataIngestion.Tests.MakdownChunker
 
                     if (leadingHashes == markdownHeaderLevel)
                     {
-                        lastHeader = line;                        
+                        lastHeader = line;
                     }
                     else if (leadingHashes < markdownHeaderLevel)
                     {
@@ -99,7 +99,7 @@ namespace Microsoft.Extensions.DataIngestion.Tests.MakdownChunker
             string textContent = content.ToString();
             if (string.IsNullOrWhiteSpace(textContent))
                 return null;
-            return new Chunk(textContent, context: context); 
+            return new Chunk(textContent, context: context);
         }
 
         private static int CountLeadingHashes(string line)

--- a/test/Microsoft.Extensions.DataIngestion.Tests/MakdownChunker/MarkdownChunkerTests.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/MakdownChunker/MarkdownChunkerTests.cs
@@ -1,0 +1,174 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Extensions.DataIngestion.Tests.MakdownChunker
+{
+    public class MarkdownChunkerTests
+    {
+        protected DocumentChunker CreateDocumentChunker()
+        {
+            return new MarkdownChunker();
+        }
+
+        [Fact]
+        public async Task EmptyDocument()
+        {
+            Document emptyDoc = new("emptyDoc");
+            DocumentChunker chunker = CreateDocumentChunker();
+
+            List<Chunk> chunks = await chunker.ProcessAsync(emptyDoc);
+            Assert.Empty(chunks);
+        }
+
+        [Fact]
+        public async Task NoheaderDocument()
+        {
+            Document noHeaerDoc = new Document("noHeaderDoc")
+            {
+                Markdown = "This is a document without headers.".ReplaceLineEndings()
+            };
+            DocumentChunker chunker = CreateDocumentChunker();
+            List<Chunk> chunks = await chunker.ProcessAsync(noHeaerDoc);
+            Assert.True(chunks.Count == 1);
+
+            Chunk chunk = chunks.First();
+            Assert.Equal("This is a document without headers.", chunk.Content.Trim());
+            Assert.Equal(chunk.Context, string.Empty);
+        }
+
+        [Fact]
+        public async Task SingleHeaderDocument()
+        {
+            Document singleHeaderDoc = new Document("singleHeaderDoc")
+            {
+                Markdown = "# Header 1\nThis is the content under header 1.".ReplaceLineEndings()
+            };
+            DocumentChunker chunker = CreateDocumentChunker();
+            List<Chunk> chunks = await chunker.ProcessAsync(singleHeaderDoc);
+            Assert.True(chunks.Count == 1);
+            Chunk chunk = chunks.First();
+            Assert.Equal("# Header 1", chunk.Context);
+            Assert.Equal("This is the content under header 1.", chunk.Content.Trim());
+        }
+
+        [Fact]
+        public async Task SingleHeaderTwoParagraphDocument()
+        {
+            string content = "This is the first paragraph.\n\nThis is the second paragraph.".ReplaceLineEndings();
+            Document singleHeaderTwoParagraphDoc = new Document("singleHeaderTwoParagraphDoc")
+            {
+                Markdown = "# Header 1\n" + content
+            };
+            DocumentChunker chunker = CreateDocumentChunker();
+            List<Chunk> chunks = await chunker.ProcessAsync(singleHeaderTwoParagraphDoc);
+            Assert.True(chunks.Count == 1);
+            Chunk chunk = chunks.First();
+            Assert.Equal("# Header 1", chunk.Context);
+            Assert.Equal(content, chunk.Content.Trim());
+        }
+
+        [Fact]
+        public async Task MultiHeaderDocument()
+        {
+            string content1 = "This is the content under header 1.".ReplaceLineEndings();
+            string content2 = "This is the content under header 2.".ReplaceLineEndings();
+            Document multiHeaderDoc = new Document("multiHeaderDoc")
+            {
+                Markdown = "# Header 1\n" + content1 + "\n## Header 2\n" + content2
+            };
+            DocumentChunker chunker = new MarkdownChunker();
+            List<Chunk> chunks = await chunker.ProcessAsync(multiHeaderDoc);
+            Assert.True(chunks.Count == 2);
+            Chunk chunk1 = chunks[0];
+            Assert.Equal("# Header 1", chunk1.Context);
+            Assert.Equal(content1, chunk1.Content.Trim());
+            Chunk chunk2 = chunks[1];
+            Assert.Equal("# Header 1;## Header 2", chunk2.Context);
+            Assert.Equal(content2, chunk2.Content.Trim());
+        }
+
+        [Fact]
+        public async Task TwoHeaderDocument()
+        {
+            string content1 = "This is the content under header 1.".ReplaceLineEndings();
+            string content2 = "This is the content under header 2.".ReplaceLineEndings();
+            Document twoHeaderDoc = new Document("twoHeaderDoc")
+            {
+                Markdown = "# Header 1\n" + content1 + "\n# Header 2\n" + content2
+            };
+            DocumentChunker chunker = CreateDocumentChunker();
+            List<Chunk> chunks = await chunker.ProcessAsync(twoHeaderDoc);
+            Assert.True(chunks.Count == 2);
+            Chunk chunk1 = chunks[0];
+            Assert.Equal("# Header 1", chunk1.Context);
+            Assert.Equal(content1, chunk1.Content.Trim());
+            Chunk chunk2 = chunks[1];
+            Assert.Equal("# Header 2", chunk2.Context);
+            Assert.Equal(content2, chunk2.Content.Trim());
+        }
+
+        [Fact]
+        public async Task ComplexDocument()
+        {
+            string content1 = "This is the content under header 1.".ReplaceLineEndings();
+            string content2 = "This is the content under header 2.".ReplaceLineEndings();
+            string content3 = "This is the content under header 3.".ReplaceLineEndings();
+            string content4 = "This is the content under header 4.".ReplaceLineEndings();
+            Document complexDoc = new Document("complexDoc")
+            {
+                Markdown = "# Header 1\n" + content1 +
+                           "\n## Header 2\n" + content2 +
+                           "\n### Header 3\n" + content3 +
+                           "\n## Header 4\n" + content4
+            };
+            DocumentChunker chunker = CreateDocumentChunker();
+            List<Chunk> chunks = await chunker.ProcessAsync(complexDoc);
+            Assert.True(chunks.Count == 4);
+            Chunk chunk1 = chunks[0];
+            Assert.Equal("# Header 1", chunk1.Context);
+            Assert.Equal(content1, chunk1.Content.Trim());
+            Chunk chunk2 = chunks[1];
+            Assert.Equal("# Header 1;## Header 2", chunk2.Context);
+            Assert.Equal(content2, chunk2.Content.Trim());
+            Chunk chunk3 = chunks[2];
+            Assert.Equal("# Header 1;## Header 2;### Header 3", chunk3.Context);
+            Assert.Equal(content3, chunk3.Content.Trim());
+            Chunk chunk4 = chunks[3];
+            Assert.Equal("# Header 1;## Header 4", chunk4.Context);
+            Assert.Equal(content4, chunk4.Content.Trim());
+        }
+
+        [Fact]
+        public async Task ComplexDocument_SplitOnLowerLevel()
+        {
+            string content1 = "This is the content under header 1.".ReplaceLineEndings();
+            string content2 = "This is the content under header 2.".ReplaceLineEndings();
+            string content3 = "This is the content under header 3.".ReplaceLineEndings();
+            string content4 = "This is the content under header 4.".ReplaceLineEndings();
+            Document complexDoc = new Document("complexDoc")
+            {
+                Markdown = "# Header 1\n" + content1 +
+                           "\n## Header 2\n" + content2 +
+                           "\n### Header 3\n" + content3 +
+                           "\n## Header 4\n" + content4
+            };
+            DocumentChunker chunker = new MarkdownChunker(MarkdownHeaderLevel.Header2);
+            List<Chunk> chunks = await chunker.ProcessAsync(complexDoc);
+            Assert.True(chunks.Count == 3);
+            Chunk chunk1 = chunks[0];
+            Assert.Equal("# Header 1", chunk1.Context);
+            Assert.Equal(content1, chunk1.Content.Trim());
+            Chunk chunk2 = chunks[1];
+            Assert.Equal("# Header 1;## Header 2", chunk2.Context);
+            Assert.Equal((content2 + "\n### Header 3\n" + content3).ReplaceLineEndings(), chunk2.Content.Trim());
+            Chunk chunk3 = chunks[2];
+            Assert.Equal("# Header 1;## Header 4", chunk3.Context);
+            Assert.Equal(content4, chunk3.Content.Trim());
+        }
+    }
+}

--- a/test/Microsoft.Extensions.DataIngestion.Tests/MakdownChunker/MarkdownChunkerTests.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/MakdownChunker/MarkdownChunkerTests.cs
@@ -6,24 +6,16 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Microsoft.Extensions.DataIngestion.Tests.MakdownChunker
+namespace Microsoft.Extensions.DataIngestion.Tests
 {
-    public class MarkdownChunkerTests
+    public class MarkdownChunkerTests : DocumentChunkerTests
     {
-        protected DocumentChunker CreateDocumentChunker()
+        override protected DocumentChunker CreateDocumentChunker()
         {
             return new MarkdownChunker();
         }
 
-        [Fact]
-        public async Task EmptyDocument()
-        {
-            Document emptyDoc = new("emptyDoc");
-            DocumentChunker chunker = CreateDocumentChunker();
-
-            List<Chunk> chunks = await chunker.ProcessAsync(emptyDoc);
-            Assert.Empty(chunks);
-        }
+        
 
         [Fact]
         public async Task NoheaderDocument()

--- a/test/Microsoft.Extensions.DataIngestion.Tests/Microsoft.Extensions.DataIngestion.Tests.csproj
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/Microsoft.Extensions.DataIngestion.Tests.csproj
@@ -47,6 +47,7 @@
     <None Include="**/*.cs" />
     <None Remove="DocumentTokenChunker\DocumentTokenChunker.cs" />
     <None Remove="DocumentTokenChunker\DocumentTokenChunkerTests.cs" />
+    <None Remove="DummyChunkerTests.cs" />
     <None Remove="MakdownChunker\MarkdownChunker.cs" />
     <None Remove="MakdownChunker\MarkdownChunkerTests.cs" />
     <None Update="TestFiles\*.*">

--- a/test/Microsoft.Extensions.DataIngestion.Tests/Microsoft.Extensions.DataIngestion.Tests.csproj
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/Microsoft.Extensions.DataIngestion.Tests.csproj
@@ -43,8 +43,25 @@
   <ItemGroup>
     <!-- Workaround https://github.com/dotnet/project-system/issues/935 -->
     <None Include="**/*.cs" />
+    <None Remove="MakdownChunker\MarkdownChunker.cs" />
+    <None Remove="MakdownChunker\MarkdownChunkerTests.cs" />
     <None Update="TestFiles\*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
     </None>
   </ItemGroup>
 

--- a/test/Microsoft.Extensions.DataIngestion.Tests/Microsoft.Extensions.DataIngestion.Tests.csproj
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/Microsoft.Extensions.DataIngestion.Tests.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="LlamaParse" Version="0.1.1" />
     <PackageReference Include="Markdig" Version="0.41.3" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.8.0-preview.1.25412.6" />
+    <PackageReference Include="Microsoft.ML.Tokenizers" Version="2.0.0-preview.25373.1" />
+    <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="2.0.0-preview.25373.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.InMemory" Version="1.63.0-preview" />
     <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0-preview.6.25358.103" />
@@ -43,6 +45,8 @@
   <ItemGroup>
     <!-- Workaround https://github.com/dotnet/project-system/issues/935 -->
     <None Include="**/*.cs" />
+    <None Remove="DocumentTokenChunker\DocumentTokenChunker.cs" />
+    <None Remove="DocumentTokenChunker\DocumentTokenChunkerTests.cs" />
     <None Remove="MakdownChunker\MarkdownChunker.cs" />
     <None Remove="MakdownChunker\MarkdownChunkerTests.cs" />
     <None Update="TestFiles\*.*">


### PR DESCRIPTION
Implementation of two simple chunkers.

Changes: 
- Markdown chunker (inspired by langchain MarkdownHeaderTextSplitter) 
- TokenCount chunker (inspired by chonkie TokenChunker)
- Common test base for chunkers
- Token count in chunks optional 