### PR TITLE
extend DocumentElement with lazy-allocated Metadata that allows to store parser-specific info

### DIFF
--- a/src/Microsoft.Extensions.DataIngestion.Abstractions/Document.cs
+++ b/src/Microsoft.Extensions.DataIngestion.Abstractions/Document.cs
@@ -32,11 +32,15 @@ namespace Microsoft.Extensions.DataIngestion
     [DebuggerDisplay("{GetType().Name}: {Markdown}")]
     public abstract class DocumentElement
     {
+        private Dictionary<string, object?>? _metadata;
+
         public string Text { get; set; } = string.Empty;
 
         public virtual string Markdown { get; set; } = string.Empty;
 
         public int? PageNumber { get; set; }
+
+        public Dictionary<string, object?> Metadata => _metadata ??= new();
     }
 
     /// <summary>

--- a/test/Microsoft.Extensions.DataIngestion.Tests/AzureDocInt/DocumentIntelligenceReader.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/AzureDocInt/DocumentIntelligenceReader.cs
@@ -160,6 +160,9 @@ namespace Microsoft.Extensions.DataIngestion.Tests
                             var paragraph = MapToElement(parsedParagraph, markdown);
                             paragraph.Markdown = markdown;
                             paragraph.PageNumber = GetPageNumber(parsedParagraph.BoundingRegions);
+                            paragraph.Metadata[nameof(AdiParagraph.BoundingRegions)] = parsedParagraph.BoundingRegions;
+                            paragraph.Metadata[nameof(AdiParagraph.Role)] = parsedParagraph.Role;
+
                             section.Elements.Add(paragraph);
                             break;
                         case "table":
@@ -169,6 +172,14 @@ namespace Microsoft.Extensions.DataIngestion.Tests
                             {
                                 PageNumber = GetPageNumber(parsedTable.BoundingRegions),
                                 Markdown = GetMarkdown(parsedTable.Spans, entireContent),
+                                Metadata =
+                                {
+                                    { nameof(parsedTable.RowCount), parsedTable.RowCount },
+                                    { nameof(parsedTable.ColumnCount), parsedTable.ColumnCount },
+                                    { nameof(parsedTable.BoundingRegions), parsedTable.BoundingRegions },
+                                    { nameof(parsedTable.Caption), parsedTable.Caption },
+                                    { nameof(parsedTable.Footnotes), parsedTable.Footnotes }
+                                }
                             });
                             break;
                         case "figure":
@@ -181,6 +192,13 @@ namespace Microsoft.Extensions.DataIngestion.Tests
                                 PageNumber = GetPageNumber(figure.BoundingRegions),
                                 Text = figure.Caption?.Content ?? "",
                                 Markdown = GetMarkdown(figure.Spans, entireContent),
+                                Metadata =
+                                {
+                                    { nameof(figure.Id), figure.Id },
+                                    { nameof(figure.BoundingRegions), figure.BoundingRegions },
+                                    { nameof(figure.Caption), figure.Caption },
+                                    { nameof(figure.Footnotes), figure.Footnotes },
+                                }
                             });
                             break;
                         default:

--- a/test/Microsoft.Extensions.DataIngestion.Tests/LlamaParse/LlamaParseReader.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/LlamaParse/LlamaParseReader.cs
@@ -121,7 +121,13 @@ public class LlamaParseReader : DocumentReader
             {
                 Text = parsedPage.Text,
                 Markdown = parsedPage.Markdown,
-                PageNumber = parsedPage.PageNumber
+                PageNumber = parsedPage.PageNumber,
+                Metadata =
+                {
+                    { nameof(Page.Width), parsedPage.Width },
+                    { nameof(Page.Height), parsedPage.Height },
+                    { nameof(Page.Confidence), parsedPage.Confidence },
+                }
             };
 
             if (!string.IsNullOrEmpty(parsedPage.PageHeaderMarkdown))
@@ -155,6 +161,7 @@ public class LlamaParseReader : DocumentReader
                 };
                 element.PageNumber = parsedPage.PageNumber;
                 element.Markdown = item.Markdown;
+                element.Metadata[nameof(PageItem.BoundingBox)] = item.BoundingBox;
 
                 page.Elements.Add(element);
             }
@@ -168,13 +175,20 @@ public class LlamaParseReader : DocumentReader
                 // the Base64 string might become the standard instead of BinaryData.
                 BinaryData binaryData = BinaryData.FromBytes(Convert.FromBase64String(image.Image!));
 
-                page.Elements.Add(new DocumentImage()
+                DocumentImage documentImage = new()
                 {
                     Content = binaryData,
                     MediaType = image.ImageMimetype,
                     PageNumber = parsedPage.PageNumber,
                     Text = image.Text ?? string.Empty,
-                });
+                };
+
+                foreach (var kvp in image.Metadata)
+                {
+                    documentImage.Metadata[kvp.Key] = kvp.Value;
+                }
+
+                page.Elements.Add(documentImage);
             }
 
             if (!string.IsNullOrEmpty(parsedPage.PageFooterMarkdown))


### PR DESCRIPTION
fixes #28