### PR TITLE
make Document.Markdown mandatory to provide when creating elements

### DIFF
--- a/src/Microsoft.Extensions.DataIngestion.Abstractions/Document.cs
+++ b/src/Microsoft.Extensions.DataIngestion.Abstractions/Document.cs
@@ -63,11 +63,20 @@ public sealed class Document : IEnumerable<DocumentElement>
 [DebuggerDisplay("{GetType().Name}: {Markdown}")]
 public abstract class DocumentElement
 {
+    protected string _markdown;
+
+    protected DocumentElement(string markdown)
+    {
+        _markdown = string.IsNullOrEmpty(markdown) ? throw new ArgumentNullException(nameof(markdown)) : markdown;
+    }
+
+    protected internal DocumentElement() => _markdown = null!;
+
     private Dictionary<string, object?>? _metadata;
 
     public string Text { get; set; } = string.Empty;
 
-    public virtual string Markdown { get; set; } = string.Empty;
+    public virtual string Markdown => _markdown;
 
     public int? PageNumber { get; set; }
 
@@ -79,28 +88,41 @@ public abstract class DocumentElement
 /// </summary>
 public sealed class DocumentSection : DocumentElement
 {
-    private string? _markdown;
+    public DocumentSection(string markdown) : base(markdown)
+    {
+    }
+
+    // the user is not providing the Markdown, we will compute it from the elements
+    public DocumentSection() : base()
+    {
+    }
 
     public List<DocumentElement> Elements { get; } = [];
 
-    public override string Markdown
-    {
-        get => _markdown ??= string.Join("", Elements.Select(e => e.Markdown));
-        set => _markdown = value;
-    }
+    public override string Markdown => _markdown ??= string.Join("", Elements.Select(e => e.Markdown));
 }
 
 public sealed class DocumentParagraph : DocumentElement
 {
+    public DocumentParagraph(string markdown) : base(markdown)
+    {
+    }
 }
 
 public sealed class DocumentHeader : DocumentElement
 {
+    public DocumentHeader(string markdown) : base(markdown)
+    {
+    }
+
     public int? Level { get; set; }
 }
 
 public sealed class DocumentFooter : DocumentElement
 {
+    public DocumentFooter(string markdown) : base(markdown)
+    {
+    }
 }
 
 public sealed class DocumentTable : DocumentElement
@@ -108,10 +130,17 @@ public sealed class DocumentTable : DocumentElement
     // So far, we only support Markdown representation of the table
     // because "LLMs speak Markdown" and there was no need to access
     // individual rows/columns/cells.
+    public DocumentTable(string markdown) : base(markdown)
+    {
+    }
 }
 
 public sealed class DocumentImage : DocumentElement
 {
+    public DocumentImage(string markdown) : base(markdown)
+    {
+    }
+
     public BinaryData? Content { get; set; }
 
     public string? MediaType { get; set; }

--- a/src/Microsoft.Extensions.DataIngestion/Processors/DocumentFlattener.cs
+++ b/src/Microsoft.Extensions.DataIngestion/Processors/DocumentFlattener.cs
@@ -19,12 +19,9 @@ public class DocumentFlattener : IDocumentProcessor
             throw new ArgumentNullException(nameof(document));
         }
 
-        DocumentSection rootSection = new()
-        {
-            // Since we have a single section that contains all elements,
-            // we can treat the Markdown of the whole Document as the section's Markdown.
-            Markdown = document.Markdown,
-        };
+        // Since we have a single section that contains all elements,
+        // we can treat the Markdown of the whole Document as the section's Markdown.
+        DocumentSection rootSection = new(document.Markdown);
 
         rootSection.Elements.AddRange(document.Where(element => element is not DocumentSection));
 

--- a/test/Microsoft.Extensions.DataIngestion.Tests/AlternativeTextEnricherTests.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/AlternativeTextEnricherTests.cs
@@ -14,9 +14,10 @@ public class AlternativeTextEnricherTests : ChatClientTestBase
     public async Task CanGenerateImageAltText()
     {
         AlternativeTextEnricher sut = new(ChatClient);
-        ReadOnlyMemory<byte> imageContent = await File.ReadAllBytesAsync(Path.Combine("TestFiles", "SampleImage.png"));
+        string imagePath = Path.Combine("TestFiles", "SampleImage.png");
+        ReadOnlyMemory<byte> imageContent = await File.ReadAllBytesAsync(imagePath);
 
-        DocumentImage documentImage = new()
+        DocumentImage documentImage = new($"![]({imagePath})")
         {
             AlternativeText = null,
             Content = BinaryData.FromBytes(imageContent),

--- a/test/Microsoft.Extensions.DataIngestion.Tests/Chunkers/DocumentTokenChunkerTests.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/Chunkers/DocumentTokenChunkerTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.DataIngestion.Tests.Chunkers
             {
                 Elements =
                 {
-                    new DocumentParagraph { Markdown = text }
+                    new DocumentParagraph(text)
                 }
             });
 
@@ -58,7 +58,7 @@ namespace Microsoft.Extensions.DataIngestion.Tests.Chunkers
             {
                 Elements =
                 {
-                    new DocumentParagraph { Markdown = text }
+                    new DocumentParagraph(text)
                 }
             });
             IDocumentChunker chunker = CreateNoOverlapTokenChkunker();
@@ -83,7 +83,7 @@ namespace Microsoft.Extensions.DataIngestion.Tests.Chunkers
             {
                 Elements =
                 {
-                    new DocumentParagraph { Markdown = text }
+                    new DocumentParagraph(text)
                 }
             });
 

--- a/test/Microsoft.Extensions.DataIngestion.Tests/Chunkers/MarkdownChunkerTests.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/Chunkers/MarkdownChunkerTests.cs
@@ -24,10 +24,7 @@ namespace Microsoft.Extensions.DataIngestion.Tests.Chunkers
             {
                 Elements =
                 {
-                    new DocumentParagraph
-                    {
-                        Markdown = "This is a document without headers.".ReplaceLineEndings()
-                    }
+                    new DocumentParagraph("This is a document without headers.")
                 }
             });
 
@@ -48,15 +45,11 @@ namespace Microsoft.Extensions.DataIngestion.Tests.Chunkers
             {
                 Elements =
                 {
-                    new DocumentHeader
+                    new DocumentHeader("# Header 1")
                     {
-                        Markdown = "# Header 1",
                         Level = 1
                     },
-                    new DocumentParagraph
-                    {
-                        Markdown = "This is the content under header 1.".ReplaceLineEndings()
-                    }
+                    new DocumentParagraph("This is the content under header 1.")
                 }
             });
 
@@ -77,19 +70,12 @@ namespace Microsoft.Extensions.DataIngestion.Tests.Chunkers
             {
                 Elements =
                 {
-                    new DocumentHeader
+                    new DocumentHeader("# Header 1")
                     {
-                        Markdown = "# Header 1",
                         Level = 1
                     },
-                    new DocumentParagraph
-                    {
-                        Markdown = "This is the first paragraph."
-                    },
-                    new DocumentParagraph
-                    {
-                        Markdown = "This is the second paragraph."
-                    }
+                    new DocumentParagraph("This is the first paragraph."),
+                    new DocumentParagraph("This is the second paragraph.")
                 }
             });
             IDocumentChunker chunker = CreateDocumentChunker();
@@ -111,24 +97,16 @@ namespace Microsoft.Extensions.DataIngestion.Tests.Chunkers
             {
                 Elements =
                 {
-                    new DocumentHeader
+                    new DocumentHeader("# Header 1")
                     {
-                        Markdown = "# Header 1",
                         Level = 1
                     },
-                    new DocumentParagraph
+                    new DocumentParagraph(content1),
+                    new DocumentHeader("## Header 2")
                     {
-                        Markdown = content1
-                    },
-                    new DocumentHeader
-                    {
-                        Markdown = "## Header 2",
                         Level = 2
                     },
-                    new DocumentParagraph
-                    {
-                        Markdown = content2
-                    }
+                    new DocumentParagraph(content2)
                 }
             });
             IDocumentChunker chunker = new MarkdownChunker();
@@ -154,24 +132,16 @@ namespace Microsoft.Extensions.DataIngestion.Tests.Chunkers
             {
                 Elements =
                 {
-                    new DocumentHeader
+                    new DocumentHeader("# Header 1")
                     {
-                        Markdown = "# Header 1",
                         Level = 1
                     },
-                    new DocumentParagraph
+                    new DocumentParagraph(content1),
+                    new DocumentHeader("# Header 2")
                     {
-                        Markdown = content1
-                    },
-                    new DocumentHeader
-                    {
-                        Markdown = "# Header 2",
                         Level = 1
                     },
-                    new DocumentParagraph
-                    {
-                        Markdown = content2
-                    }
+                    new DocumentParagraph(content2)
                 }
             });
             IDocumentChunker chunker = CreateDocumentChunker();
@@ -199,42 +169,26 @@ namespace Microsoft.Extensions.DataIngestion.Tests.Chunkers
             {
                 Elements =
                 {
-                    new DocumentHeader
+                    new DocumentHeader("# Header 1")
                     {
-                        Markdown = "# Header 1",
                         Level = 1
                     },
-                    new DocumentParagraph
+                    new DocumentParagraph(content1),
+                    new DocumentHeader("## Header 2")
                     {
-                        Markdown = content1
-                    },
-                    new DocumentHeader
-                    {
-                        Markdown = "## Header 2",
                         Level = 2
                     },
-                    new DocumentParagraph
+                    new DocumentParagraph(content2),
+                    new DocumentHeader("### Header 3")
                     {
-                        Markdown = content2
-                    },
-                    new DocumentHeader
-                    {
-                        Markdown = "### Header 3",
                         Level = 3
                     },
-                    new DocumentParagraph
+                    new DocumentParagraph(content3),
+                    new DocumentHeader("## Header 4")
                     {
-                        Markdown = content3
-                    },
-                    new DocumentHeader
-                    {
-                        Markdown = "## Header 4",
                         Level = 2
                     },
-                    new DocumentParagraph
-                    {
-                        Markdown = content4
-                    }
+                    new DocumentParagraph(content4)
                 }
             });
             IDocumentChunker chunker = CreateDocumentChunker();
@@ -271,42 +225,26 @@ namespace Microsoft.Extensions.DataIngestion.Tests.Chunkers
             {
                 Elements =
                 {
-                    new DocumentHeader
+                    new DocumentHeader("# Header 1")
                     {
-                        Markdown = "# Header 1",
                         Level = 1
                     },
-                    new DocumentParagraph
+                    new DocumentParagraph(content1),
+                    new DocumentHeader("## Header 2")
                     {
-                        Markdown = content1
-                    },
-                    new DocumentHeader
-                    {
-                        Markdown = "## Header 2",
                         Level = 2
                     },
-                    new DocumentParagraph
+                    new DocumentParagraph(content2),
+                    new DocumentHeader("### Header 3")
                     {
-                        Markdown = content2
-                    },
-                    new DocumentHeader
-                    {
-                        Markdown = "### Header 3",
                         Level = 3
                     },
-                    new DocumentParagraph
+                    new DocumentParagraph(content3),
+                    new DocumentHeader("## Header 4")
                     {
-                        Markdown = content3
-                    },
-                    new DocumentHeader
-                    {
-                        Markdown = "## Header 4",
                         Level = 2
                     },
-                    new DocumentParagraph
-                    {
-                        Markdown = content4
-                    }
+                    new DocumentParagraph(content4)
                 }
             });
             IDocumentChunker chunker = new MarkdownChunker(2);

--- a/test/Microsoft.Extensions.DataIngestion.Tests/DocumentChunkerTests.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/DocumentChunkerTests.cs
@@ -32,21 +32,10 @@ namespace Microsoft.Extensions.DataIngestion.Tests
         }
 
         [Fact]
-        public async Task EmptyParagraphDocument()
+        public void EmptyParagraphDocumentCantBeCreated()
         {
-            Document emptyDoc = new("emptyDoc");
-            emptyDoc.Sections.Add(new DocumentSection
-            {
-                Elements =
-                {
-                    new DocumentParagraph()
-                }
-            });
-
-            IDocumentChunker chunker = CreateDocumentChunker();
-
-            List<DocumentChunk> chunks = await chunker.ProcessAsync(emptyDoc);
-            Assert.Empty(chunks);
+            Assert.Throws<ArgumentNullException>(() => new DocumentParagraph(null!));
+            Assert.Throws<ArgumentNullException>(() => new DocumentParagraph(""));
         }
     }
 }

--- a/test/Microsoft.Extensions.DataIngestion.Tests/DocumentFlattenerTests.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/DocumentFlattenerTests.cs
@@ -17,30 +17,27 @@ public class DocumentFlattenerTests
         };
         doc.Sections.Add(new DocumentSection
         {
-            Markdown = "first section",
             Elements =
             {
-                new DocumentHeader { Markdown = "header" },
-                new DocumentParagraph { Markdown = "paragraph" },
-                new DocumentTable { Markdown = "table" },
+                new DocumentHeader("header"),
+                new DocumentParagraph("paragraph"),
+                new DocumentTable("table"),
                 new DocumentSection
                 {
-                    Markdown = "nested section",
                     Elements =
                     {
-                        new DocumentHeader { Markdown = "nested header" },
-                        new DocumentParagraph { Markdown = "nested paragraph" }
+                        new DocumentHeader("nested header"),
+                        new DocumentParagraph("nested paragraph")
                     }
                 }
             }
         });
         doc.Sections.Add(new DocumentSection
         {
-            Markdown = "second section",
             Elements =
             {
-                new DocumentHeader { Markdown = "header 2" },
-                new DocumentParagraph { Markdown = "paragraph 2" }
+                new DocumentHeader("header 2"),
+                new DocumentParagraph("paragraph 2")
             }
         });
 

--- a/test/Microsoft.Extensions.DataIngestion.Tests/DocumentTests.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/DocumentTests.cs
@@ -15,32 +15,29 @@ public class DocumentTests
         {
             Markdown = "same",
         };
-        doc.Sections.Add(new DocumentSection
+        doc.Sections.Add(new DocumentSection("first section")
         {
-            Markdown = "first section",
             Elements =
             {
-                new DocumentHeader { Markdown = "header" },
-                new DocumentParagraph { Markdown = "paragraph" },
-                new DocumentTable { Markdown = "table" },
-                new DocumentSection
+                new DocumentHeader("header"),
+                new DocumentParagraph("paragraph"),
+                new DocumentTable("table"),
+                new DocumentSection("nested section")
                 {
-                    Markdown = "nested section",
                     Elements =
                     {
-                        new DocumentHeader { Markdown = "nested header" },
-                        new DocumentParagraph { Markdown = "nested paragraph" }
+                        new DocumentHeader("nested header"),
+                        new DocumentParagraph("nested paragraph")
                     }
                 }
             }
         });
-        doc.Sections.Add(new DocumentSection
+        doc.Sections.Add(new DocumentSection("second section")
         {
-            Markdown = "second section",
             Elements =
             {
-                new DocumentHeader { Markdown = "header 2" },
-                new DocumentParagraph { Markdown = "paragraph 2" }
+                new DocumentHeader("header 2"),
+                new DocumentParagraph("paragraph 2")
             }
         });
 

--- a/test/Microsoft.Extensions.DataIngestion.Tests/HeaderChunkerTests.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/HeaderChunkerTests.cs
@@ -17,22 +17,21 @@ public class HeaderChunkerTests
         Document doc = new("nonTrivial");
         doc.Sections.Add(new DocumentSection
         {
-            Markdown = "first section",
             Elements =
             {
-                new DocumentHeader { Markdown = "Header 1", Level = 1 },
-                    new DocumentHeader { Markdown = "Header 1_1", Level = 2 },
-                        new DocumentParagraph { Markdown = "Paragraph 1_1_1" },
-                        new DocumentHeader { Markdown = "Header 1_1_1", Level = 3 },
-                            new DocumentParagraph { Markdown = "Paragraph 1_1_1_1" },
-                            new DocumentParagraph { Markdown = "Paragraph 1_1_1_2" },
-                        new DocumentHeader { Markdown = "Header 1_1_2", Level = 3 },
-                            new DocumentParagraph { Markdown = "Paragraph 1_1_2_1" },
-                            new DocumentParagraph { Markdown = "Paragraph 1_1_2_2" },
-                    new DocumentHeader { Markdown = "Header 1_2", Level = 2 },
-                        new DocumentParagraph { Markdown = "Paragraph 1_2_1" },
-                        new DocumentHeader { Markdown = "Header 1_2_1", Level = 3 },
-                            new DocumentParagraph { Markdown = "Paragraph 1_2_1_1" },
+                new DocumentHeader("Header 1") { Level = 1 },
+                    new DocumentHeader("Header 1_1") { Level = 2 },
+                        new DocumentParagraph("Paragraph 1_1_1"),
+                        new DocumentHeader("Header 1_1_1") { Level = 3 },
+                            new DocumentParagraph("Paragraph 1_1_1_1"),
+                            new DocumentParagraph("Paragraph 1_1_1_2"),
+                        new DocumentHeader("Header 1_1_2") { Level = 3 },
+                            new DocumentParagraph("Paragraph 1_1_2_1"),
+                            new DocumentParagraph("Paragraph 1_1_2_2"),
+                    new DocumentHeader("Header 1_2") { Level = 2 },
+                        new DocumentParagraph("Paragraph 1_2_1"),
+                        new DocumentHeader("Header 1_2_1") { Level = 3 },
+                            new DocumentParagraph("Paragraph 1_2_1_1"),
             }
         });
 


### PR DESCRIPTION
Based on feedback from @KrystofS I believe that we should ensure that all elements always come with markdown provided. So let's just request it to be provided at creation time, with the exception of section, which can be represented as joined markdown of its children elements.

contributes to #23