### PR TITLE
don't include sections in the document enumerator

### DIFF
--- a/src/Microsoft.Extensions.DataIngestion.Abstractions/Document.cs
+++ b/src/Microsoft.Extensions.DataIngestion.Abstractions/Document.cs
@@ -41,6 +41,9 @@ public sealed class Document : IEnumerable<DocumentElement>
     /// <summary>
     /// Iterate over all elements in the document, including those in nested sections.
     /// </summary>
+    /// <remarks>
+    /// Sections themselves are not included.
+    /// </remarks>
     public IEnumerator<DocumentElement> GetEnumerator()
     {
         Stack<DocumentElement> elementsToProcess = new();
@@ -54,9 +57,11 @@ public sealed class Document : IEnumerable<DocumentElement>
         {
             DocumentElement currentElement = elementsToProcess.Pop();
 
-            yield return currentElement;
-
-            if (currentElement is DocumentSection nestedSection)
+            if (currentElement is not DocumentSection nestedSection)
+            {
+                yield return currentElement;
+            }
+            else
             {
                 for (int i = nestedSection.Elements.Count - 1; i >= 0; i--)
                 {

--- a/src/Microsoft.Extensions.DataIngestion/Chunkers/MarkdownChunker.cs
+++ b/src/Microsoft.Extensions.DataIngestion/Chunkers/MarkdownChunker.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.DataIngestion.Chunkers
         {
             if (document is null) throw new ArgumentNullException(nameof(document));
 
-            IEnumerable<DocumentElement> elements = document.Where(element => element is not DocumentSection).Reverse();
+            IEnumerable<DocumentElement> elements = document.Reverse();
             var sectionStack = new Stack<DocumentElement>(elements);
 
             return Task.FromResult(ParseLevel(sectionStack, 1));

--- a/src/Microsoft.Extensions.DataIngestion/Chunkers/SemanticChunker.cs
+++ b/src/Microsoft.Extensions.DataIngestion/Chunkers/SemanticChunker.cs
@@ -37,8 +37,7 @@ namespace Microsoft.Extensions.DataIngestion.Chunkers
                 return [];
             }
 
-            IEnumerable<DocumentElement> elements = document.Where(element => element is not DocumentSection);
-            IEnumerable<string> units = elements.Select(GetSemanticContent);
+            IEnumerable<string> units = document.Select(GetSemanticContent);
             Task<List<(string, float)>> sentenceDistances = CalculateDistances(units.ToArray());
 
             return MakeChunks(await sentenceDistances);

--- a/src/Microsoft.Extensions.DataIngestion/Processors/DocumentFlattener.cs
+++ b/src/Microsoft.Extensions.DataIngestion/Processors/DocumentFlattener.cs
@@ -23,7 +23,7 @@ public class DocumentFlattener : IDocumentProcessor
         // we can treat the Markdown of the whole Document as the section's Markdown.
         DocumentSection rootSection = new(document.Markdown);
 
-        rootSection.Elements.AddRange(document.Where(element => element is not DocumentSection));
+        rootSection.Elements.AddRange(document);
 
         Document flat = new(document.Identifier)
         {

--- a/test/Microsoft.Extensions.DataIngestion.Tests/DocumentTests.cs
+++ b/test/Microsoft.Extensions.DataIngestion.Tests/DocumentTests.cs
@@ -44,26 +44,20 @@ public class DocumentTests
 
         DocumentElement[] flatElements = doc.ToArray();
 
-        Assert.IsType<DocumentSection>(flatElements[0]);
-        Assert.Equal("first section", flatElements[0].Markdown);
-        Assert.IsType<DocumentHeader>(flatElements[1]);
-        Assert.Equal("header", flatElements[1].Markdown);
-        Assert.IsType<DocumentParagraph>(flatElements[2]);
-        Assert.Equal("paragraph", flatElements[2].Markdown);
-        Assert.IsType<DocumentTable>(flatElements[3]);
-        Assert.Equal("table", flatElements[3].Markdown);
-        Assert.IsType<DocumentSection>(flatElements[4]);
-        Assert.Equal("nested section", flatElements[4].Markdown);
+        Assert.IsType<DocumentHeader>(flatElements[0]);
+        Assert.Equal("header", flatElements[0].Markdown);
+        Assert.IsType<DocumentParagraph>(flatElements[1]);
+        Assert.Equal("paragraph", flatElements[1].Markdown);
+        Assert.IsType<DocumentTable>(flatElements[2]);
+        Assert.Equal("table", flatElements[2].Markdown);
+        Assert.IsType<DocumentHeader>(flatElements[3]);
+        Assert.Equal("nested header", flatElements[3].Markdown);
+        Assert.IsType<DocumentParagraph>(flatElements[4]);
+        Assert.Equal("nested paragraph", flatElements[4].Markdown);
         Assert.IsType<DocumentHeader>(flatElements[5]);
-        Assert.Equal("nested header", flatElements[5].Markdown);
+        Assert.Equal("header 2", flatElements[5].Markdown);
         Assert.IsType<DocumentParagraph>(flatElements[6]);
-        Assert.Equal("nested paragraph", flatElements[6].Markdown);
-        Assert.IsType<DocumentSection>(flatElements[7]);
-        Assert.Equal("second section", flatElements[7].Markdown);
-        Assert.IsType<DocumentHeader>(flatElements[8]);
-        Assert.Equal("header 2", flatElements[8].Markdown);
-        Assert.IsType<DocumentParagraph>(flatElements[9]);
-        Assert.Equal("paragraph 2", flatElements[9].Markdown);
+        Assert.Equal("paragraph 2", flatElements[6].Markdown);
     }
 
     [Theory]


### PR DESCRIPTION
 as they are excluded everywhere and handling them should require extra caution (updating `Markdown` on updates)

cc @KrystofS 