### PR TITLE
add MarkItDown MCP reader

### DIFF
--- a/src/AspireSamples/AspireSamples.AppHost/Program.cs
+++ b/src/AspireSamples/AspireSamples.AppHost/Program.cs
@@ -1,5 +1,9 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
+var markitdown = builder.AddContainer("markitdown", "mcp/markitdown")
+    .WithArgs("--http", "--port", "3001")
+    .WithHttpEndpoint(targetPort: 3001, name: "http");
+
 var ollama = builder.AddOllama("ollama")
     .WithDataVolume();
 var chat = ollama.AddModel("chat", "llama3.2");
@@ -18,5 +22,7 @@ webApp
 webApp
     .WithReference(vectorDB)
     .WaitFor(vectorDB);
+
+webApp.WithEnvironment("MARKITDOWN_MCP_URL", markitdown.GetEndpoint("http"));
 
 builder.Build().Run();

--- a/src/AspireSamples/AspireSamples.AppHost/Program.cs
+++ b/src/AspireSamples/AspireSamples.AppHost/Program.cs
@@ -1,7 +1,7 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 var markitdown = builder.AddContainer("markitdown", "mcp/markitdown")
-    .WithArgs("--http", "--port", "3001")
+    .WithArgs("--http", "--host", "0.0.0.0", "--port", "3001")
     .WithHttpEndpoint(targetPort: 3001, name: "http");
 
 var ollama = builder.AddOllama("ollama")

--- a/src/AspireSamples/AspireSamples.Web/Services/Ingestion/DataIngestor.cs
+++ b/src/AspireSamples/AspireSamples.Web/Services/Ingestion/DataIngestor.cs
@@ -24,8 +24,10 @@ public class DataIngestor(
             IncrementalIngestion = true
         });
 
+        string url = $"{Environment.GetEnvironmentVariable("MARKITDOWN_MCP_URL")}/mcp";
+
         using IngestionPipeline<string> pipeline = new(
-            new MarkItDownReader(), // requires MarkItDown to be installed and in PATH
+            new MarkItDownMcpReader(new Uri(url)),
             new SemanticSimilarityChunker(embeddingGenerator, new(TiktokenTokenizer.CreateForModel("gpt-4o"))),
             writer,
             // [new SummaryEnricher(chatClient)], takes too much time for samples

--- a/src/Microsoft.Extensions.DataIngestion.MarkItDown/MarkItDownMcpReader.cs
+++ b/src/Microsoft.Extensions.DataIngestion.MarkItDown/MarkItDownMcpReader.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+
+namespace Microsoft.Extensions.DataIngestion;
+
+/// <summary>
+/// Reads documents by converting them to Markdown using the <see href="https://github.com/microsoft/markitdown">MarkItDown</see> MCP server.
+/// </summary>
+public class MarkItDownMcpReader : IngestionDocumentReader
+{
+    private readonly Uri _mcpServerUri;
+    private readonly McpClientOptions? _mcpOptions;
+    private readonly MarkdownReader _markdownReader = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MarkItDownMcpReader"/> class.
+    /// </summary>
+    /// <param name="mcpServerUri">The URI of the MarkItDown MCP server (e.g., http://localhost:3001/mcp).</param>
+    public MarkItDownMcpReader(Uri mcpServerUri, McpClientOptions? mcpOptions = null)
+    {
+        _mcpServerUri = mcpServerUri ?? throw new ArgumentNullException(nameof(mcpServerUri));
+        _mcpOptions = mcpOptions;
+    }
+
+    /// <inheritdoc/>
+    public override async Task<IngestionDocument> ReadAsync(FileInfo source, string identifier, string? mediaType = null, CancellationToken cancellationToken = default)
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+        else if (string.IsNullOrEmpty(identifier))
+        {
+            throw new ArgumentNullException(nameof(identifier));
+        }
+        else if (!source.Exists)
+        {
+            throw new FileNotFoundException("The specified file does not exist.", source.FullName);
+        }
+
+#if NET
+        byte[] fileBytes = await File.ReadAllBytesAsync(source.FullName, cancellationToken).ConfigureAwait(false);
+#else
+        byte[] fileBytes;
+        using (FileStream fs = new(source.FullName, FileMode.Open, FileAccess.Read, FileShare.Read, 1, FileOptions.Asynchronous))
+        {
+            using MemoryStream ms = new();
+            await fs.CopyToAsync(ms).ConfigureAwait(false);
+            fileBytes = ms.ToArray();
+        }
+#endif
+        string dataUri = BuildDataUri(mediaType, fileBytes);
+        string markdown = await ConvertToMarkdownAsync(dataUri, cancellationToken).ConfigureAwait(false);
+
+        return _markdownReader.Read(markdown, identifier);
+    }
+
+    /// <inheritdoc/>
+    public override async Task<IngestionDocument> ReadAsync(Stream source, string identifier, string mediaType, CancellationToken cancellationToken = default)
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+        else if (string.IsNullOrEmpty(identifier))
+        {
+            throw new ArgumentNullException(nameof(identifier));
+        }
+
+        // Read stream content as base64 data URI
+        using MemoryStream ms = new();
+#if NET
+        await source.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
+        await source.CopyToAsync(ms).ConfigureAwait(false);
+#endif
+        string dataUri = BuildDataUri(mediaType, ms);
+        string markdown = await ConvertToMarkdownAsync(dataUri, cancellationToken).ConfigureAwait(false);
+
+        return _markdownReader.Read(markdown, identifier);
+    }
+
+    private static string BuildDataUri(string? mediaType, MemoryStream memoryStream)
+    {
+        string base64Content = memoryStream.TryGetBuffer(out var buffer)
+            ? Convert.ToBase64String(buffer.Array!, buffer.Offset, buffer.Count)
+            : Convert.ToBase64String(memoryStream.ToArray());
+
+        string mimeType = string.IsNullOrEmpty(mediaType) ? "application/octet-stream" : mediaType!;
+        return $"data:{mimeType};base64,{base64Content}";
+    }
+
+    private static string BuildDataUri(string? mediaType, byte[] fileBytes)
+    {
+        string base64Content = Convert.ToBase64String(fileBytes);
+        string mimeType = string.IsNullOrEmpty(mediaType) ? "application/octet-stream" : mediaType!;
+        string dataUri = $"data:{mimeType};base64,{base64Content}";
+        return dataUri;
+    }
+
+    private async Task<string> ConvertToMarkdownAsync(string dataUri, CancellationToken cancellationToken)
+    {
+        await using HttpClientTransport transport = new(new HttpClientTransportOptions
+        {
+            Endpoint = _mcpServerUri
+        });
+
+        await using McpClient client = await McpClient.CreateAsync(transport, _mcpOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        Dictionary<string, object?> parameters = new()
+        {
+            ["uri"] = dataUri
+        };
+
+        CallToolResult result = await client.CallToolAsync("convert_to_markdown", parameters, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        // Extract markdown content from result
+        // The result is expected to be in the format: { "content": [{ "type": "text", "text": "markdown content" }] }
+        if (result.Content != null && result.Content.Count > 0)
+        {
+            foreach (var content in result.Content)
+            {
+                if (content.Type == "text" && content is TextContentBlock textBlock)
+                {
+                    return textBlock.Text;
+                }
+            }
+        }
+
+        throw new InvalidOperationException("Failed to convert document to markdown: unexpected response format from MCP server.");
+    }
+}

--- a/src/Microsoft.Extensions.DataIngestion.MarkItDown/Microsoft.Extensions.DataIngestion.MarkItDown.csproj
+++ b/src/Microsoft.Extensions.DataIngestion.MarkItDown/Microsoft.Extensions.DataIngestion.MarkItDown.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" Version="0.4.0-preview.3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.Extensions.DataIngestion.Markdown\Microsoft.Extensions.DataIngestion.Markdown.csproj" />
   </ItemGroup>
 

--- a/src/Microsoft.Extensions.DataIngestion.MarkItDown/Microsoft.Extensions.DataIngestion.MarkItDown.csproj
+++ b/src/Microsoft.Extensions.DataIngestion.MarkItDown/Microsoft.Extensions.DataIngestion.MarkItDown.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol" Version="0.4.0-preview.3" />
+    <PackageReference Include="ModelContextProtocol.Core" Version="0.4.0-preview.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Edit: nvm, I got it to work thanks to Eirik.

<details>

Based on these docs: https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp

I run:

```cmd
docker run -p 56890:3001 mcp/markitdown --http --port 3001
```

And it says it's listening

```log
INFO:     Started server process [1]
INFO:     Waiting for application startup.
StreamableHTTP session manager started
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:3001 (Press CTRL+C to quit)
```

It's listening on 3001 inside the container, and my understanding is that it should listen on 56890 on my machine.

But when I try to connect to `http://127.0.0.1:56890/mcp` via C# SDK I get:

"Unable to read data from the transport connection: An established connection was aborted by the software in your host machine.."

I've tried using the `mcpinspector` tool:

```cmd
npx @modelcontextprotocol/inspector
```

And followed these very simple instructions https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp#debugging:

But I just can't connect:

<img width="542" height="1004" alt="image" src="https://github.com/user-attachments/assets/d1a08057-fbd2-46a3-bfe9-e9c13f9c1086" />

</details>